### PR TITLE
Regex in builder

### DIFF
--- a/src/characterchain/builder.rs
+++ b/src/characterchain/builder.rs
@@ -1,8 +1,8 @@
-use std::ops::Deref;
 use crate::characterchain::generator::CharacterChainGenerator;
-use multimarkov::MultiMarkov;
 use multimarkov::builder::MultiMarkovBuilder;
+use multimarkov::MultiMarkov;
 use rand::RngCore;
+use std::ops::Deref;
 
 /// A Builder pattern for CharacterChainGenerator.
 pub struct CharacterChainGeneratorBuilder<'a> {
@@ -36,7 +36,7 @@ impl<'a> CharacterChainGeneratorBuilder<'a> {
     ///
     /// NOTE: Order should be set *before* training the model with `.train()`
     pub fn with_order(mut self, order: i32) -> Self {
-        assert!(order > 0,"Order must be an integer greater than zero.");
+        assert!(order > 0, "Order must be an integer greater than zero.");
         self.model = self.model.with_order(order); // update model now, so it'll affect training
         self
     }
@@ -70,11 +70,16 @@ impl<'a> CharacterChainGeneratorBuilder<'a> {
     /// Ingest a training data set to train the model.
     /// The argument 'sequences' is an iterator of either `String` or `&str` values, the words or names
     /// that we want our randomly generated text to resemble.
-    pub fn train(mut self, sequences: impl Iterator<Item=impl Deref<Target = str>>) -> Self {
-        self.model = self.model.train( sequences
-            .map(|s| s.to_lowercase()) // lowercase the input
-            .map(|mut s| { s.insert(0, '#'); s.push('#'); s }) // add the beginning-of-character and end-of-character strings
-            .map(|s| s.chars().collect()) // turn the input stream into an iterator of Vec<char>
+    pub fn train(mut self, sequences: impl Iterator<Item = impl Deref<Target = str>>) -> Self {
+        self.model = self.model.train(
+            sequences
+                .map(|s| s.to_lowercase()) // lowercase the input
+                .map(|mut s| {
+                    s.insert(0, '#');
+                    s.push('#');
+                    s
+                }) // add the beginning-of-character and end-of-character strings
+                .map(|s| s.chars().collect()), // turn the input stream into an iterator of Vec<char>
         );
         self
     }
@@ -85,7 +90,6 @@ impl<'a> CharacterChainGeneratorBuilder<'a> {
             pattern: self.pattern,
         }
     }
-
 }
 
 #[cfg(test)]
@@ -94,11 +98,15 @@ mod tests {
 
     #[test]
     fn test_builder_pattern_works() {
-        let generator = CharacterChainGenerator::builder().with_order(2).with_prior(0.007).with_pattern("foo").build();
+        let generator = CharacterChainGenerator::builder()
+            .with_order(2)
+            .with_prior(0.007)
+            .with_pattern("foo")
+            .build();
     }
 
     #[test]
-    #[should_panic(expected="Order must be an integer greater than zero.")]
+    #[should_panic(expected = "Order must be an integer greater than zero.")]
     fn test_order_cannot_be_less_than_one() {
         let generator = CharacterChainGenerator::builder().with_order(0).build();
     }
@@ -106,10 +114,11 @@ mod tests {
     #[test]
     fn test_can_train_model_with_vec_of_strings() {
         // Training works equally well with an iterator of Strings or an iterator of &strs.
-        let inputs = vec!["dopey","sneezy","bashful","sleepy","happy","grumpy","doc"].into_iter();
+        let inputs = vec![
+            "dopey", "sneezy", "bashful", "sleepy", "happy", "grumpy", "doc",
+        ]
+        .into_iter();
         //let inputs_as_strings = vec![String::from("dopey"),String::from("sneezy"),String::from("bashful"),String::from("sleepy"),String::from("happy"),String::from("grumpy"),String::from("doc")].into_iter();
         let generator = CharacterChainGenerator::builder().train(inputs).build();
     }
-
-
 }

--- a/src/characterchain/builder.rs
+++ b/src/characterchain/builder.rs
@@ -2,6 +2,7 @@ use crate::characterchain::generator::CharacterChainGenerator;
 use multimarkov::builder::MultiMarkovBuilder;
 use multimarkov::MultiMarkov;
 use rand::RngCore;
+use regex::Regex;
 use std::ops::Deref;
 
 /// A Builder pattern for CharacterChainGenerator.
@@ -84,10 +85,11 @@ impl<'a> CharacterChainGeneratorBuilder<'a> {
         self
     }
     /// Build the CharacterChainGenerator (consuming the "Builder" in the process).
-    pub fn build(self) -> CharacterChainGenerator<'a> {
+    pub fn build(self) -> CharacterChainGenerator {
+        let pattern = self.pattern.map(|pat| Regex::new(pat).unwrap());
         CharacterChainGenerator {
             model: self.model.build(),
-            pattern: self.pattern,
+            pattern,
         }
     }
 }

--- a/src/characterchain/builder.rs
+++ b/src/characterchain/builder.rs
@@ -98,7 +98,7 @@ mod tests {
 
     #[test]
     fn test_builder_pattern_works() {
-        let generator = CharacterChainGenerator::builder()
+        let _generator = CharacterChainGenerator::builder()
             .with_order(2)
             .with_prior(0.007)
             .with_pattern("foo")
@@ -108,7 +108,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Order must be an integer greater than zero.")]
     fn test_order_cannot_be_less_than_one() {
-        let generator = CharacterChainGenerator::builder().with_order(0).build();
+        let _generator = CharacterChainGenerator::builder().with_order(0).build();
     }
 
     #[test]
@@ -119,6 +119,6 @@ mod tests {
         ]
         .into_iter();
         //let inputs_as_strings = vec![String::from("dopey"),String::from("sneezy"),String::from("bashful"),String::from("sleepy"),String::from("happy"),String::from("grumpy"),String::from("doc")].into_iter();
-        let generator = CharacterChainGenerator::builder().train(inputs).build();
+        let _generator = CharacterChainGenerator::builder().train(inputs).build();
     }
 }

--- a/src/characterchain/generator.rs
+++ b/src/characterchain/generator.rs
@@ -78,15 +78,14 @@ impl<'a> CharacterChainGenerator<'a> {
         // start with the beginning-of-word character
         let mut name = vec!['#'];
         name.push(self.model.random_next(&name).unwrap());
-        while !name.ends_with(&*vec!['#']) {
+        while !name.ends_with(&['#']) {
             // keep adding letters until we reach the end-of-word character
             name.push(self.model.random_next(&name).unwrap());
         }
         // remove the trailing and leading "#" signs
         name.pop();
         name.remove(0);
-        let stringname = name.iter().collect::<String>();
-        stringname
+        name.iter().collect::<String>()
     }
 }
 
@@ -97,7 +96,7 @@ impl RandomTextGenerator for CharacterChainGenerator<'_> {
             Some(pattern) => {
                 let re = Regex::new(pattern).unwrap();
                 let mut candidate = self.generate_string();
-                while !re.is_match(&*candidate) {
+                while !re.is_match(&candidate) {
                     //println!("got '{}', re-rolling!", candidate);
                     candidate = self.generate_string();
                 }

--- a/src/characterchain/generator.rs
+++ b/src/characterchain/generator.rs
@@ -1,7 +1,7 @@
-use regex::Regex;
 use crate::characterchain::builder::CharacterChainGeneratorBuilder;
 use crate::interface::RandomTextGenerator;
 use multimarkov::MultiMarkov;
+use regex::Regex;
 
 /// This struct, once trained on a corpus of training data, can be used repeatedly to generate
 /// random text strings (i.e. names) that sort-of resemble the training data.  At its heart is a

--- a/src/characterchain/generator.rs
+++ b/src/characterchain/generator.rs
@@ -61,12 +61,12 @@ use regex::Regex;
 /// }
 /// ```
 ///
-pub struct CharacterChainGenerator<'a> {
+pub struct CharacterChainGenerator {
     pub(super) model: MultiMarkov<char>,
-    pub(super) pattern: Option<&'a str>,
+    pub(super) pattern: Option<Regex>,
 }
 
-impl<'a> CharacterChainGenerator<'a> {
+impl<'a> CharacterChainGenerator {
     pub const DEFAULT_ORDER: i32 = 3;
     pub const DEFAULT_PRIOR: f64 = 0.005;
 
@@ -89,12 +89,11 @@ impl<'a> CharacterChainGenerator<'a> {
     }
 }
 
-impl RandomTextGenerator for CharacterChainGenerator<'_> {
+impl RandomTextGenerator for CharacterChainGenerator {
     fn generate_one(&mut self) -> String {
-        match self.pattern {
+        match self.pattern.clone() {
             None => self.generate_string(),
-            Some(pattern) => {
-                let re = Regex::new(pattern).unwrap();
+            Some(re) => {
                 let mut candidate = self.generate_string();
                 while !re.is_match(&candidate) {
                     //println!("got '{}', re-rolling!", candidate);

--- a/src/characterchain/mod.rs
+++ b/src/characterchain/mod.rs
@@ -1,5 +1,2 @@
-pub mod generator;
 pub mod builder;
-
-
-
+pub mod generator;

--- a/src/clusterchain/builder.rs
+++ b/src/clusterchain/builder.rs
@@ -3,8 +3,8 @@ use is_vowel::IsRomanceVowel;
 use multimarkov::builder::MultiMarkovBuilder;
 use multimarkov::MultiMarkov;
 use rand::RngCore;
+use regex::Regex;
 use std::ops::Deref;
-
 /// A Builder pattern for ClusterChainGenerator.
 pub struct ClusterChainGeneratorBuilder<'a> {
     model: MultiMarkovBuilder<String>,
@@ -117,10 +117,11 @@ impl<'a> ClusterChainGeneratorBuilder<'a> {
     }
 
     /// Build the ClusterChainGenerator (consuming the "Builder" in the process).
-    pub fn build(self) -> ClusterChainGenerator<'a> {
+    pub fn build(self) -> ClusterChainGenerator {
+        let pattern = self.pattern.map(|pat| Regex::new(pat).unwrap());
         ClusterChainGenerator {
             model: self.model.build(),
-            pattern: self.pattern,
+            pattern,
         }
     }
 }

--- a/src/clusterchain/builder.rs
+++ b/src/clusterchain/builder.rs
@@ -77,7 +77,7 @@ impl<'a> ClusterChainGeneratorBuilder<'a> {
         self.model = self.model.train(
             sequences
                 .map(|s| s.to_lowercase()) // lowercase the input
-                .map(|s| ClusterChainGeneratorBuilder::clusterize(s))
+                .map(ClusterChainGeneratorBuilder::clusterize)
                 .map(|mut s| {
                     s.insert(0, "#".to_string());
                     s.push("#".to_string());
@@ -165,7 +165,7 @@ mod tests {
 
     #[test]
     fn test_builder_pattern_works() {
-        let generator = ClusterChainGenerator::builder()
+        let _generator = ClusterChainGenerator::builder()
             .with_order(2)
             .with_prior(0.007)
             .with_pattern("foo")
@@ -175,7 +175,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "Order must be an integer greater than zero.")]
     fn test_order_cannot_be_less_than_one() {
-        let generator = ClusterChainGenerator::builder().with_order(0).build();
+        let _generator = ClusterChainGenerator::builder().with_order(0).build();
     }
 
     #[test]
@@ -185,6 +185,6 @@ mod tests {
             "dopey", "sneezy", "bashful", "sleepy", "happy", "grumpy", "doc",
         ]
         .into_iter();
-        let generator = ClusterChainGenerator::builder().train(inputs).build();
+        let _generator = ClusterChainGenerator::builder().train(inputs).build();
     }
 }

--- a/src/clusterchain/builder.rs
+++ b/src/clusterchain/builder.rs
@@ -1,9 +1,9 @@
-use std::ops::Deref;
+use crate::clusterchain::generator::ClusterChainGenerator;
+use is_vowel::IsRomanceVowel;
 use multimarkov::builder::MultiMarkovBuilder;
 use multimarkov::MultiMarkov;
 use rand::RngCore;
-use crate::clusterchain::generator::ClusterChainGenerator;
-use is_vowel::IsRomanceVowel;
+use std::ops::Deref;
 
 /// A Builder pattern for ClusterChainGenerator.
 pub struct ClusterChainGeneratorBuilder<'a> {
@@ -12,7 +12,6 @@ pub struct ClusterChainGeneratorBuilder<'a> {
 }
 
 impl<'a> ClusterChainGeneratorBuilder<'a> {
-
     /// Instantiate a new builder with default values.
     pub fn new() -> Self {
         Self {
@@ -38,7 +37,7 @@ impl<'a> ClusterChainGeneratorBuilder<'a> {
     ///
     /// NOTE: Order should be set *before* training the model with `.train()`
     pub fn with_order(mut self, order: i32) -> Self {
-        assert!(order > 0,"Order must be an integer greater than zero.");
+        assert!(order > 0, "Order must be an integer greater than zero.");
         self.model = self.model.with_order(order); // update model now, so it'll affect training
         self
     }
@@ -74,11 +73,16 @@ impl<'a> ClusterChainGeneratorBuilder<'a> {
     /// Ingest a training data set to train the model.
     /// The argument 'sequences' is an iterator of either `String` or `&str` values, the words or names
     /// that we want our randomly generated text to resemble.
-    pub fn train(mut self, sequences: impl Iterator<Item=impl Deref<Target = str>>) -> Self {
-        self.model = self.model.train( sequences
-                                           .map(|s| s.to_lowercase()) // lowercase the input
-                                           .map(|s| ClusterChainGeneratorBuilder::clusterize(s))
-                                           .map(|mut s| { s.insert(0, "#".to_string()); s.push("#".to_string()); s }) // add the beginning-of-character and end-of-character strings
+    pub fn train(mut self, sequences: impl Iterator<Item = impl Deref<Target = str>>) -> Self {
+        self.model = self.model.train(
+            sequences
+                .map(|s| s.to_lowercase()) // lowercase the input
+                .map(|s| ClusterChainGeneratorBuilder::clusterize(s))
+                .map(|mut s| {
+                    s.insert(0, "#".to_string());
+                    s.push("#".to_string());
+                    s
+                }), // add the beginning-of-character and end-of-character strings
         );
         self
     }
@@ -119,15 +123,14 @@ impl<'a> ClusterChainGeneratorBuilder<'a> {
             pattern: self.pattern,
         }
     }
-
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-    use is_vowel::IsRomanceVowel;
     use crate::clusterchain::builder::ClusterChainGeneratorBuilder;
     use crate::clusterchain::generator::ClusterChainGenerator;
+    use is_vowel::IsRomanceVowel;
+    use std::collections::HashSet;
 
     #[test]
     fn test_is_vowel_crate_works() {
@@ -140,7 +143,7 @@ mod tests {
         assert!(!'b'.is_romance_vowel());
         assert!(!'y'.is_romance_vowel());
         assert!('ĳ'.is_romance_vowel());
-        let extra_vowels : HashSet<char> = "yæœøɏʎ".chars().collect();  // treat 'y' as a vowel, too (and some non-romance vowels)
+        let extra_vowels: HashSet<char> = "yæœøɏʎ".chars().collect(); // treat 'y' as a vowel, too (and some non-romance vowels)
         assert!('y'.is_romance_vowel_including(&extra_vowels));
         assert!('ǣ'.is_romance_vowel_including(&extra_vowels));
         assert!('ǿ'.is_romance_vowel_including(&extra_vowels));
@@ -148,17 +151,29 @@ mod tests {
 
     #[test]
     fn test_clusterize() {
-        assert_eq!(ClusterChainGeneratorBuilder::clusterize(String::from("foobar")),
-                   vec!["f".to_string(),"oo".to_string(),"b".to_string(),"a".to_string(),"r".to_string()]);
+        assert_eq!(
+            ClusterChainGeneratorBuilder::clusterize(String::from("foobar")),
+            vec![
+                "f".to_string(),
+                "oo".to_string(),
+                "b".to_string(),
+                "a".to_string(),
+                "r".to_string()
+            ]
+        );
     }
 
     #[test]
     fn test_builder_pattern_works() {
-        let generator = ClusterChainGenerator::builder().with_order(2).with_prior(0.007).with_pattern("foo").build();
+        let generator = ClusterChainGenerator::builder()
+            .with_order(2)
+            .with_prior(0.007)
+            .with_pattern("foo")
+            .build();
     }
 
     #[test]
-    #[should_panic(expected="Order must be an integer greater than zero.")]
+    #[should_panic(expected = "Order must be an integer greater than zero.")]
     fn test_order_cannot_be_less_than_one() {
         let generator = ClusterChainGenerator::builder().with_order(0).build();
     }
@@ -166,8 +181,10 @@ mod tests {
     #[test]
     fn test_can_train_model_with_vec_of_strings() {
         // Training works equally well with an iterator of Strings or an iterator of &strs.
-        let inputs = vec!["dopey","sneezy","bashful","sleepy","happy","grumpy","doc"].into_iter();
+        let inputs = vec![
+            "dopey", "sneezy", "bashful", "sleepy", "happy", "grumpy", "doc",
+        ]
+        .into_iter();
         let generator = ClusterChainGenerator::builder().train(inputs).build();
     }
-
 }

--- a/src/clusterchain/generator.rs
+++ b/src/clusterchain/generator.rs
@@ -90,15 +90,14 @@ impl<'a> ClusterChainGenerator<'a> {
         // start with the beginning-of-word character
         let mut name = vec!["#".to_string()];
         name.push(self.model.random_next(&name).unwrap());
-        while !name.ends_with(&*vec!["#".to_string()]) {
+        while !name.ends_with(&["#".to_string()]) {
             // keep adding letters until we reach the end-of-word character
             name.push(self.model.random_next(&name).unwrap());
         }
         // remove the trailing and leading "#" signs
         name.pop();
         name.remove(0);
-        let stringname = name.join("");
-        stringname
+        name.join("")
     }
 }
 
@@ -109,7 +108,7 @@ impl RandomTextGenerator for ClusterChainGenerator<'_> {
             Some(pattern) => {
                 let re = Regex::new(pattern).unwrap();
                 let mut candidate = self.generate_string();
-                while !re.is_match(&*candidate) {
+                while !re.is_match(&candidate) {
                     //println!("got '{}', re-rolling!", candidate);
                     candidate = self.generate_string();
                 }

--- a/src/clusterchain/generator.rs
+++ b/src/clusterchain/generator.rs
@@ -73,12 +73,12 @@ use regex::Regex;
 /// }
 /// ```
 ///
-pub struct ClusterChainGenerator<'a> {
+pub struct ClusterChainGenerator {
     pub(super) model: MultiMarkov<String>,
-    pub(super) pattern: Option<&'a str>,
+    pub(super) pattern: Option<Regex>,
 }
 
-impl<'a> ClusterChainGenerator<'a> {
+impl<'a> ClusterChainGenerator {
     pub const DEFAULT_ORDER: i32 = 3;
     pub const DEFAULT_PRIOR: f64 = 0.001;
 
@@ -101,12 +101,11 @@ impl<'a> ClusterChainGenerator<'a> {
     }
 }
 
-impl RandomTextGenerator for ClusterChainGenerator<'_> {
+impl RandomTextGenerator for ClusterChainGenerator {
     fn generate_one(&mut self) -> String {
-        match self.pattern {
+        match self.pattern.clone() {
             None => self.generate_string(),
-            Some(pattern) => {
-                let re = Regex::new(pattern).unwrap();
+            Some(re) => {
                 let mut candidate = self.generate_string();
                 while !re.is_match(&candidate) {
                     //println!("got '{}', re-rolling!", candidate);

--- a/src/clusterchain/generator.rs
+++ b/src/clusterchain/generator.rs
@@ -1,14 +1,14 @@
-use multimarkov::MultiMarkov;
-use regex::Regex;
 use crate::clusterchain::builder::ClusterChainGeneratorBuilder;
 use crate::RandomTextGenerator;
+use multimarkov::MultiMarkov;
+use regex::Regex;
 
 /// This struct, once trained on a corpus of training data, can be used repeatedly to generate
 /// random text strings (i.e. names) that sort-of resemble the training data.  At its heart is a
 /// Markov chain model.  The key difference between this struct and its cousin `CharacterChainGenerator`
 /// is that this one learns vowel and consonant *clusters* and the relative probabilities with which
 /// one cluster follows another.  
-/// 
+///
 /// So, from a string like `"fascinating"` it learns the following transitions:
 ///
 /// - `"f"` or `"n"` -> `"a"`

--- a/src/clusterchain/mod.rs
+++ b/src/clusterchain/mod.rs
@@ -1,2 +1,2 @@
-pub mod generator;
 pub mod builder;
+pub mod generator;

--- a/src/interface.rs
+++ b/src/interface.rs
@@ -1,4 +1,3 @@
-
 pub trait RandomTextGenerator {
     fn generate_one(&mut self) -> String;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
-pub mod interface;
 pub mod characterchain;
 pub mod clusterchain;
+pub mod interface;
 
 pub use characterchain::generator::CharacterChainGenerator;
 pub use clusterchain::generator::ClusterChainGenerator;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,27 +1,26 @@
 mod characterchain;
 mod interface;
 
-use std::fs::File;
-use std::io::{BufReader, BufRead};
-use rand::SeedableRng;
 use rand::rngs::SmallRng;
+use rand::SeedableRng;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
 
 use crate::characterchain::generator::CharacterChainGenerator;
 use crate::interface::RandomTextGenerator;
 
 fn main() {
-
     // Test of CharacterChainGenerator
     println!("Ten Roman names from CharacterChainGenerator:\n");
 
     let file = File::open("resources/romans.txt").unwrap();
     let reader = BufReader::new(file);
-    let lines = reader.lines().map(|l| l.unwrap() );
+    let lines = reader.lines().map(|l| l.unwrap());
 
     let mut namegen = CharacterChainGenerator::builder()
         .with_order(3)
         .with_prior(0.007)
-//        .with_pattern("^[a-z]*a$") // names ending with "a" (feminine names)
+        //.with_pattern("^[a-z]*a$") // names ending with "a" (feminine names)
         .with_pattern("^[A-Za-z]{4,8}$") // names 4-8 characters long
         .with_rng(Box::new(SmallRng::seed_from_u64(123)))
         .train(lines)
@@ -36,12 +35,12 @@ fn main() {
 
     let file2 = File::open("resources/romans.txt").unwrap();
     let reader2 = BufReader::new(file2);
-    let lines2 = reader2.lines().map(|l| l.unwrap() );
+    let lines2 = reader2.lines().map(|l| l.unwrap());
 
     let mut namegen2 = CharacterChainGenerator::builder()
         .with_order(3)
         .with_prior(0.0005)
-//        .with_pattern("^[a-z]*a$") // names ending with "a" (feminine names)
+        //.with_pattern("^[a-z]*a$") // names ending with "a" (feminine names)
         .with_pattern("^[A-Za-z]{4,8}$") // names 4-8 characters long
         .with_rng(Box::new(SmallRng::seed_from_u64(123)))
         .train(lines2)
@@ -50,8 +49,4 @@ fn main() {
     for _i in 0..10 {
         println!("{}", namegen2.generate_one());
     }
-
-
 }
-
-


### PR DESCRIPTION
I was playing around with your crate and doing some stuff (which I don't know if it will work out or not yet),
But during that I noticed that moving the call to `Regex::new` should speed up the call to `generate_one()`.
This fixes that after going through rustfmt and fixing clippy lints.

I didn't do actual perf testing though there are some discussion by burntsushi in the following
https://www.reddit.com/r/rust/comments/un4pha/how_to_build_a_cache_that_can_retrieve_multiple/
> cloning a regex does not do a full deep copy of the entire compiled regex object. 

and a bit of discussion of cloning regexs here
https://docs.rs/regex/latest/regex/index.html#sharing-a-regex-across-threads-can-result-in-contention