### PR TITLE
Using loop avoid some minor code duplication

### DIFF
--- a/src/characterchain/generator.rs
+++ b/src/characterchain/generator.rs
@@ -77,10 +77,12 @@ impl<'a> CharacterChainGenerator {
     fn generate_string(&mut self) -> String {
         // start with the beginning-of-word character
         let mut name = vec!['#'];
-        name.push(self.model.random_next(&name).unwrap());
-        while !name.ends_with(&['#']) {
+        loop {
             // keep adding letters until we reach the end-of-word character
             name.push(self.model.random_next(&name).unwrap());
+            if name.ends_with(&['#']) {
+                break
+            }
         }
         // remove the trailing and leading "#" signs
         name.pop();

--- a/src/clusterchain/generator.rs
+++ b/src/clusterchain/generator.rs
@@ -89,10 +89,12 @@ impl<'a> ClusterChainGenerator {
     fn generate_string(&mut self) -> String {
         // start with the beginning-of-word character
         let mut name = vec!["#".to_string()];
-        name.push(self.model.random_next(&name).unwrap());
-        while !name.ends_with(&["#".to_string()]) {
+        loop {
             // keep adding letters until we reach the end-of-word character
             name.push(self.model.random_next(&name).unwrap());
+            if name.ends_with(&["#".to_string()]) {
+                break;
+            }
         }
         // remove the trailing and leading "#" signs
         name.pop();


### PR DESCRIPTION
This one is pretty darn subjective, i.e. by all means just close this if you prefer the while loop.
Anyhow using loop we can avoid duplicating the contents of the while loop outside of the loop on the first iteration.

This is going to end up conflicting with the regex patch, but I figured I would just forget otherwise and didn't want to add a bunch of extra stuff to that patch...
